### PR TITLE
axum-routes-macros: support for conditional compilation

### DIFF
--- a/axum-routes/Cargo.toml
+++ b/axum-routes/Cargo.toml
@@ -21,3 +21,6 @@ name = "path_handlers"
 
 [[example]]
 name = "visibility"
+
+[[example]]
+name = "multiple_attributes"

--- a/axum-routes/examples/multiple_attributes.rs
+++ b/axum-routes/examples/multiple_attributes.rs
@@ -1,0 +1,24 @@
+#![allow(dead_code)]
+
+use axum_routes::*;
+
+pub async fn get() -> &'static str {
+    "this is a handler"
+}
+
+pub async fn single_path() -> &'static str {
+    "another handler"
+}
+
+#[routes]
+enum Router {
+    #[cfg(target_os = "linux")]
+    #[get("/", handler = get)]
+    Home,
+    #[cfg(target_os = "macos")]
+    #[get("/other", handler = single_path)]
+    Other,
+}
+fn main() {
+    let _routes = axum_routes::router!(Router);
+}


### PR DESCRIPTION
we have to specifically support conditional compilation attributes because we need to not simply add them in the enum definition, but also handle whether or not it should appear when resolving routes and adding routes in axum::Router.
This is a rough first implementation that unlocks most of use cases.