### PR TITLE
doc/example: add an example for the resolving feature fixes #10

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,12 @@ async fn main() {
         },
     );
 
+    // Resolve parameterized routes, removing the need to hardcode routes
+    assert_eq!(
+        "/api/users/42",
+        axum_routes::resolve!(MyApp::Api(APIRoutes::GetUsersByID), 42).unwrap()
+    );
+
     // run the app
     let listener = tokio::net::TcpListener::bind("0.0.0.0:3000").await.unwrap();
     axum::serve(listener, app).await.unwrap();

--- a/axum-routes/Cargo.toml
+++ b/axum-routes/Cargo.toml
@@ -16,6 +16,11 @@ axum-routes-macros.workspace = true
 axum.workspace = true
 thiserror.workspace = true
 
+[dev-dependencies]
+## External
+axum = { version = "0.8", default-features = false, features = ["json"] }
+serde_json = { version = "1.0", default-features = false }
+
 [[example]]
 name = "path_handlers"
 
@@ -24,3 +29,6 @@ name = "visibility"
 
 [[example]]
 name = "multiple_attributes"
+
+[[example]]
+name = "resolve"

--- a/axum-routes/ROUTER.md
+++ b/axum-routes/ROUTER.md
@@ -7,7 +7,7 @@ First, let's define our router as an enum:
 enum MyRoutes {
     #[get("/admin", handler = admin_handler)]
     ProtectedAdmin,
-    #[get("/assets/:asset", handler = assets)]
+    #[get("/assets/{asset}", handler = assets)]
     Assets,
 }
 
@@ -29,7 +29,7 @@ with_state. (See documentation of [MethodRouter](`axum::routing::method_routing:
 enum MyRoutes {
     #[get("/admin", handler = admin_handler, customize = protected_admin)]
     ProtectedAdmin,
-    #[get("/assets/:asset", handler = assets, customize = assets_customize)]
+    #[get("/assets/{asset}", handler = assets, customize = assets_customize)]
     Assets,
 }
 ```

--- a/axum-routes/examples/customize.rs
+++ b/axum-routes/examples/customize.rs
@@ -13,5 +13,5 @@ enum Router {
 }
 
 fn main() {
-    let _routes = axum_routes::router!(Router, home_customizer = #|route| route);
+    let _routes = axum_routes::router!(Router, home_customizer = $|route| route);
 }

--- a/axum-routes/examples/resolve.rs
+++ b/axum-routes/examples/resolve.rs
@@ -1,0 +1,54 @@
+#![allow(dead_code)]
+
+use axum::{Json, extract::Path, http::StatusCode, response::IntoResponse};
+use axum_routes::*;
+use serde_json::json;
+
+pub async fn get() -> &'static str {
+    "home"
+}
+
+pub async fn get_user_by_id(Path(_user_id): Path<u32>) -> impl IntoResponse {
+    (StatusCode::OK, Json(json!({"username": "Name"})))
+}
+
+pub async fn get_field_by_id(
+    Path(user_id): Path<u32>,
+    Path(field): Path<String>,
+) -> impl IntoResponse {
+    (
+        StatusCode::OK,
+        Json(json!({"id": user_id, "username": "Name", "field": field})),
+    )
+}
+
+#[routes]
+enum Router {
+    #[get("/", handler = get, customize = home_customizer)]
+    Home,
+    #[nest("/users")]
+    Users(Users),
+}
+
+#[routes]
+enum Users {
+    #[get("/{id}", handler = get_user_by_id)]
+    GetByID,
+    #[get("/{id}/field/{field}", handler = get_field_by_id)]
+    GetFieldByID,
+}
+
+fn main() {
+    let _routes = axum_routes::router!(Router, home_customizer = $|route| route);
+
+    // Resolve allows us to recreate the route
+    assert_eq!(
+        "/users/32",
+        axum_routes::resolve!(Router::Users(Users::GetByID), 32).unwrap()
+    );
+    assert_eq!("/32", axum_routes::resolve!(Users::GetByID, 32).unwrap());
+    assert_eq!(
+        "/users/42/field/address",
+        axum_routes::resolve!(Router::Users(Users::GetFieldByID), 42, "address").unwrap()
+    );
+}

--- a/axum-routes/src/lib.rs
+++ b/axum-routes/src/lib.rs
@@ -5,17 +5,19 @@
 //! routes in your project.
 //!
 //! ```ignore,rust
+//! # use axum_routes::routes;
+//!
 //! #[routes]
 //! enum RoutesUsers {
 //!     #[post("/", handler = create_user)]
 //!     CreateUser,
-//!     #[get("/:id", handler = get_user)]
+//!     #[get("/{id}", handler = get_user)]
 //!     GetByID,
-//!     #[put("/:id", handler = edit_user)]
+//!     #[put("/{id}", handler = edit_user)]
 //!     EditUser,
-//!     #[delete("/:id", handler = delete_user)]
+//!     #[delete("/{id}", handler = delete_user)]
 //!     DeleteByID,
-//!     #[get("/other/:id", handler = get_other_resource)]
+//!     #[get("/other/{id}", handler = get_other_resource)]
 //!     GetOtherResourceByID,
 //! }
 //!
@@ -34,11 +36,9 @@
 //! async fn get_other_resource() {}
 //! ```
 //!
-//! The route path (ie "/:id") is exactly what `axum` supports (underneath
-//! it uses the `matchit` crate. At the moment of writing, `axum` still uses
-//! `matchit 0.7.x`, so the parameters are declare `:param`. In `matchit 0.8.x`,
-//! parameters now are declared `{param}`.
-//! So to ease the process, `axum-routes` supports both.
+//! The route path (ie "/{id}") is exactly what `axum` supports (underneath
+//! it uses the `matchit` crate). Newer version of `axum` supports the
+//! `{parameter}` format instead of the old `:parameter` format.
 //!
 //! ## Resolving routes
 #![doc = include_str!("../RESOLVE.md")]


### PR DESCRIPTION
Generally, update the doc to reflect the changes in axum 0.8 with matchit 0.8 and the new parameter format ({x} instead of :x). Anyway, axum-routes support both formats.

Closes #10